### PR TITLE
refactor: Refactor readObject() to reduce complexity (#19)(#20)

### DIFF
--- a/src/main/java/com/jsoniter/IterImplObject.java
+++ b/src/main/java/com/jsoniter/IterImplObject.java
@@ -80,4 +80,70 @@ class IterImplObject {
         }
         throw iter.reportError("readObjectCB", "expect { or n");
     }
+
+    // Refactor work from Xu Zuo
+    public static final String refactoredReadObject(JsonIterator iter) throws IOException {
+        byte c = IterImpl.nextToken(iter);
+
+        if (c == 'n') {
+            return handleNull(iter);
+        }
+        if (c == '{') {
+            return processObject(iter);
+        }
+        if (c == ',') {
+            return processCommaField(iter);
+        }
+        if (c == '}') {
+            return null; // end of object
+        }
+
+        handleUnexpectedToken(iter, c);
+        return null; // Unreachable but needed for compilation
+    }
+
+    // Handles the case when 'n' (null) is encountered
+    private static String handleNull(JsonIterator iter) throws IOException {
+        IterImpl.skipFixedBytes(iter, 3);
+        return null;
+    }
+
+    // Handles objects { "key": "value" }
+    private static String processObject(JsonIterator iter) throws IOException {
+        byte c = IterImpl.nextToken(iter);
+        if (c == '"') {
+            iter.unreadByte();
+            String field = iter.readString();
+            if (IterImpl.nextToken(iter) != ':') {
+                throw iter.reportError("readObject", "expect :");
+            }
+            return field;
+        }
+        if (c == '}') {
+            return null; // End of object
+        }
+        throw iter.reportError("readObject", "expect \" after {");
+    }
+
+    // Handles the case when a comma is encountered
+    private static String processCommaField(JsonIterator iter) throws IOException {
+        String field = iter.readString();
+        if (IterImpl.nextToken(iter) != ':') {
+            throw iter.reportError("readObject", "expect :");
+        }
+        return field;
+    }
+
+    // Handles unexpected tokens
+    private static void handleUnexpectedToken(JsonIterator iter, byte c) throws IOException {
+        throw iter.reportError("readObject", "expect { or , or } or n, but found: " + (char)c);
+//        throw Error("readObject", "expect { or , or } or n, but found: " + (char) c, c);
+    }
+
+    // Centralized error handling for Jacoco visibility
+    private static void throwError(String function, String message, Object value) throws IOException {
+        System.out.println("Error in " + function + ": " + message + " - " + value);
+        throw new IOException(message);
+    }
+
 }

--- a/src/test/java/com/jsoniter/TestObject.java
+++ b/src/test/java/com/jsoniter/TestObject.java
@@ -124,6 +124,94 @@ public class TestObject extends TestCase {
 //        assertTrue(exception.getMessage().contains("expect { or , or } or n"));
 //    }
 
+    // Test for refactored readObject
+    // Xu Zuo
+    public void test_empty_object_refactor() throws IOException {
+        JsonIterator iter = JsonIterator.parse("{}");
+        assertNull(IterImplObject.refactoredReadObject(iter));
+        iter.reset(iter.buf);
+        SimpleObject simpleObj = iter.read(SimpleObject.class);
+        assertNull(simpleObj.field1);
+        iter.reset(iter.buf);
+        Object obj = iter.read(Object.class);
+        assertEquals(0, ((Map) obj).size());
+        iter.reset(iter.buf);
+        Any any = iter.readAny();
+        assertEquals(0, any.size());
+    }
+
+    public void test_one_field_refactor() throws IOException {
+        JsonIterator iter = JsonIterator.parse("{ 'field1'\r:\n\t'hello' }".replace('\'', '"'));
+        assertEquals("field1", IterImplObject.refactoredReadObject(iter));
+        assertEquals("hello", iter.readString());
+        assertNull(IterImplObject.refactoredReadObject(iter));
+        iter.reset(iter.buf);
+        SimpleObject simpleObj = iter.read(SimpleObject.class);
+        assertEquals("hello", simpleObj.field1);
+        assertNull(simpleObj.field2);
+        iter.reset(iter.buf);
+        Any any = iter.readAny();
+        assertEquals("hello", any.toString("field1"));
+        assertEquals(ValueType.INVALID, any.get("field2").valueType());
+        iter.reset(iter.buf);
+        assertEquals("hello", ((Map) iter.read()).get("field1"));
+    }
+
+    // My own/new unit tests
+    public void testReadObject_Null_refactor(){
+        assertDoesNotThrow(() -> {
+            JsonIterator iter = JsonIterator.parse("null");
+            String result = IterImplObject.refactoredReadObject(iter);
+            assertNull(result);
+        });
+    }
+
+    // if (IterImpl.nextToken(iter) != ':')`
+    public void testReadObject_MissingColon_refactor() {
+        JsonIterator iter = JsonIterator.parse("{\"key\"}");
+//        Exception exception = assertThrows(JsonException.class, () -> {
+//            iter.readObject();
+//        });
+//        assertTrue(exception.getMessage().contains("expect :"));
+        try {
+            IterImplObject.refactoredReadObject(iter);
+            fail("Expected JsonException was not thrown");
+        } catch (JsonException e) {
+            assertTrue(e.getMessage().contains("expect :"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // `case ','`
+    public void testReadObject_UnexpectedComma_refactor() {
+        JsonIterator iter = JsonIterator.parse("{,}");
+//
+//        Exception exception = assertThrows(JsonException.class, () -> {
+//            iter.readObject();
+//        });
+//        assertTrue(exception.getMessage().contains("expect \" after {"));
+        try {
+            IterImplObject.refactoredReadObject(iter);
+            fail("Expected JsonException was not thrown");
+        } catch (JsonException e) {
+            assertTrue(e.getMessage().contains("expect \" after {"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // `default`
+    public void testReadObject_UnexpectedToken_refactor () {
+        JsonIterator iter = JsonIterator.parse("[\"unexpected\"]");
+        try {
+            IterImplObject.refactoredReadObject(iter);
+            fail("Expected JsonException was not thrown");
+        } catch (JsonException | IOException e) {
+            assertTrue(e.getMessage().contains("expect { or , or } or n"));
+        }
+    }
+
     public void test_two_fields() throws IOException {
 //        JsonIterator.setMode(DecodingMode.DYNAMIC_MODE_AND_MATCH_FIELD_WITH_HASH);
         JsonIterator iter = JsonIterator.parse("{ 'field1' : 'hello' , 'field2': 'world' }".replace('\'', '"'));


### PR DESCRIPTION
## Description

- Refactored `readObject()` as `refactoredReadObject()`.
- Added helper functions for refactoring.
- Added the same unit test for `refactoredReadObject()`.

I refactored `readObject()` and reduced complexity, from 9 to 5, which reduced the complexity by 44.4% and satisfied the P+ criteria.

## Related Issues
Closes #20 